### PR TITLE
Add terminal widget to controllers

### DIFF
--- a/src/screens/ConnectedController/ConnectedController.container.tsx
+++ b/src/screens/ConnectedController/ConnectedController.container.tsx
@@ -18,6 +18,7 @@ const ConnectedControllerScreen = (props: ConnectedControllerPublicProps) => {
   const selectedCharacteristic =
     bleState.connection.targetWrite?.characteristicUUID || '';
   const controllers = useSelector((state: RootState) => state.controls);
+  const monitorLogs = useSelector((state: RootState) => state.monitor);
 
   const currentController = controllers.find((a) => a.id === id);
 
@@ -39,6 +40,7 @@ const ConnectedControllerScreen = (props: ConnectedControllerPublicProps) => {
     characteristics,
     selectCharacteristic,
     selectedCharacteristic,
+    monitorLogs,
   };
 
   return <ConnectedControllerView {...props} {...generatedProps} />;

--- a/src/screens/ConnectedController/ConnectedController.props.ts
+++ b/src/screens/ConnectedController/ConnectedController.props.ts
@@ -2,6 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Control } from 'store/controls';
 import { MainStackParamList } from 'types/Route';
+import { MonitorLog } from '../../store/monitor';
 
 export interface ConnectedControllerRouterProps {
   id?: string;
@@ -28,6 +29,7 @@ export interface ConnectedControllerGeneratedProps {
   characteristics: any[];
   selectCharacteristic: (characteristicUUID: string) => void;
   selectedCharacteristic: string;
+  monitorLogs: MonitorLog[];
 }
 
 export interface ConnectedControllerProps

--- a/src/screens/ConnectedController/ConnectedController.style.ts
+++ b/src/screens/ConnectedController/ConnectedController.style.ts
@@ -1,11 +1,12 @@
 import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 import { RootState } from 'store';
-import { getGlobalStyles } from 'theme';
+import { COLORS, getGlobalStyles } from 'theme';
 
 const useStyles = () => {
   const settings = useSelector((state: RootState) => state.settings);
   const { selectedTheme } = settings;
+  const colors = COLORS[selectedTheme];
   const STYLES = getGlobalStyles(selectedTheme);
   const styles = StyleSheet.create({
     container: STYLES.CONTAINER,
@@ -23,6 +24,14 @@ const useStyles = () => {
     },
     content: {
       flex: 1,
+    },
+    logTextContainer: {
+      paddingHorizontal: 4,
+    },
+    logText: {
+      color: colors.SECONDARY_TEXT,
+      fontSize: 14,
+      marginTop: 1,
     },
   });
 

--- a/src/screens/ControlEdit/ControlEdit.transform.tsx
+++ b/src/screens/ControlEdit/ControlEdit.transform.tsx
@@ -4,6 +4,9 @@ export const propertiesToSaveElementData = (
   elements: ControlElement[],
   labels: Record<string, string>,
   sizes: Record<string, number>,
+  heights: Record<string, number>,
+  widths: Record<string, number>,
+  types: Record<string, 'BUTTON' | 'TERMINAL'>,
   onPressCommands: Record<string, string>,
   onReleaseCommands: Record<string, string>,
 ) => {
@@ -11,6 +14,9 @@ export const propertiesToSaveElementData = (
     ...a,
     ...(labels[a.id] ? { label: labels[a.id] } : {}),
     ...(sizes[a.id] ? { size: sizes[a.id] } : {}),
+    ...(heights[a.id] ? { height: heights[a.id] } : {}),
+    ...(widths[a.id] ? { width: widths[a.id] } : {}),
+    ...(types[a.id] ? { type: types[a.id] } : {}),
     command: {
       ...a.command,
       ...(onPressCommands[a.id] ? { onPress: onPressCommands[a.id] } : {}),

--- a/src/store/controls.ts
+++ b/src/store/controls.ts
@@ -6,11 +6,14 @@ export type ControlElement = {
   x: number;
   y: number;
   label: string;
+  width: number;
+  height: number;
   size: number;
   command: {
     onPress: string;
     onRelease: string;
   };
+  type: 'BUTTON' | 'TERMINAL';
 };
 
 export type Control = {


### PR DESCRIPTION
Hi :)
This adds read-only terminals to controllers.
Terminal widgets can be created by converting a button from its edit view.
Terminals only have settable height and width.

I wasn't able to easily split `ControlElement` into Buttons and Terminals, because I haven't worked with react before. This would have made it more clean. If you want to pull this but can't because of this or other issues, let me know.